### PR TITLE
Eager load and counter cache

### DIFF
--- a/app/controllers/cocktails_controller.rb
+++ b/app/controllers/cocktails_controller.rb
@@ -4,7 +4,8 @@ class CocktailsController < ApplicationController
   wrap_parameters :cocktail, include: [:name, :description, :execution, :ingredients, :category, :user_id, :image]
 
   def index
-    cocktails = Cocktail.order(created_at: :desc)
+    # Eager load the :category, :bartender, and :photo_attachment associations
+    cocktails = Cocktail.includes(:category, :bartender, photo_attachment: :blob).order(created_at: :desc)
     render json: cocktails
   end
 

--- a/app/models/cocktail.rb
+++ b/app/models/cocktail.rb
@@ -11,10 +11,6 @@ class Cocktail < ApplicationRecord
 
   has_one_attached :photo
 
-  def likes_count
-    self.likes.size
-  end
-
   def photo_url
     Rails.application.routes.url_helpers.url_for(photo) if photo.attached?
   end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,6 +1,6 @@
 class Like < ApplicationRecord
   belongs_to :liker, :class_name => "User"
-  belongs_to :liked_cocktail, :class_name => "Cocktail"
+  belongs_to :liked_cocktail, :class_name => "Cocktail", counter_cache: :likes_count
   
   validates :liker_id, uniqueness: { scope: :liked_cocktail_id, message: "You may only like a cocktail once"}
 end

--- a/db/migrate/20240320191045_add_likes_count_to_cocktails.rb
+++ b/db/migrate/20240320191045_add_likes_count_to_cocktails.rb
@@ -1,0 +1,5 @@
+class AddLikesCountToCocktails < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cocktails, :likes_count, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2021_06_07_182147) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_20_191045) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -72,6 +72,7 @@ ActiveRecord::Schema[7.0].define(version: 2021_06_07_182147) do
     t.bigint "category_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "likes_count", default: 0, null: false
     t.index ["bartender_id"], name: "index_cocktails_on_bartender_id"
     t.index ["category_id"], name: "index_cocktails_on_category_id"
   end


### PR DESCRIPTION
1. Eager load associations in Cocktails#index to avoid N+1 queries:
- Use `includes` to eager load the `:category, :bartender, and :photo_attachment(:blob)` associations
2. Use counter cache for Likes association in Cocktail model
- remove `likes_count` which is a method of Cocktail model calculating `self.likes.size`. This method is inefficient as it requires loading the `likes` association into memory just to count them
- the database-backed counter cache helps keep track of the number of associated records in a `has_many` relationship without needing to perform an SQL counter query each time.
- a column `likes_count` is added to the `cocktails` table, with default value of 0.
- In the `Like` model, Rails is informed to maintain the `likes_count` column in the `Cocktails` table automatically whenever there is a `Like` added or removed from a Cocktail, eliminating the need for an SQL count query to get the number of `likes` for each cocktail.