### PR TITLE
Create rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,12 @@
+require:
+  - rubocop-rails
+
+AllCops:
+  TargetRubyVersion: 3.3
+  NewCops: enable
+  Exclude:
+    - "db/schema.rb"
+    - "db/migrate/**/*"
+    - "vendor/**/*"
+    - "bin/**/*"
+    - "node_modules/**/*"


### PR DESCRIPTION
## Summary

- Add `.rubocop.yml` project configuration
- Enable `rubocop-rails`
- Target Ruby 3.3
- Exclude generated and non-source files from linting:
  - `db/schema.rb`
  - `db/migrate/**/*`
  - `vendor/**/*`
  - `bin/**/*`
  - `node_modules/**/*`

## Why

This prevents RuboCop from rewriting Rails-generated files like `db/schema.rb`, which would otherwise create noisy, recurring formatting diffs after running migrations.