### PR TITLE
Infra: move local Rails backend to port 3010

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -26,7 +26,7 @@ module DrinkedInBackend
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
     config.active_support.cache_format_version = 6.1
-    config.action_mailer.default_url_options = { host: 'http://localhost:3000' }
+    config.action_mailer.default_url_options = { host: 'http://localhost:3010' }
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,5 +73,10 @@ Rails.application.configure do
 end
 
 Rails.application.routes.default_url_options = {
-  host: (ENV['HOST_URL']).to_s
+  # Set the host and protocol for URL generation in development
+  # This is used for generating URLs in mailers and other places.
+  # The host should not include the protocol (http:// or https://).
+  # The protocol can be set to "http" as it's development.
+  host: ENV.fetch('HOST_URL', 'localhost:3010').gsub(%r{https?://}, ''), 
+  protocol: "http"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     volumes:
       - .:/rails
     ports: 
-      - "3000:3000"
+      - "3010:3000"
     depends_on:
       - db
 volumes:


### PR DESCRIPTION
## Summary

- Update the local Rails backend host port from `3000` to `3010`
- Update mailer URL configuration to use the new local backend port
- Improve development `default_url_options` by supporting environment-based host/protocol configuration

## Why

This avoids local port collisions with other projects that commonly use port `3000`, while keeping Rails URL generation and mailer links aligned with the backend’s new development port.

## Notes

This is a local development infrastructure change only. It does not change production behavior or application features.