### PR TITLE
Remove eager variant processing

### DIFF
--- a/app/models/concerns/image_attachable.rb
+++ b/app/models/concerns/image_attachable.rb
@@ -24,17 +24,20 @@ module ImageAttachable
   def processed_image_url
     return unless image.attached?
 
-    Rails.application.routes.url_helpers.url_for(process_image(image))
+    Rails.application.routes.url_helpers.url_for(image_variant(image))
+  rescue StandardError => e
+    Rails.logger.error "Image processing failed for #{self.class.name} ##{id}: #{e.message}"
+    nil
   end
 
   private
 
-  def process_image(image, _content_type = image.content_type)
+  def image_variant(image, _content_type = image.content_type)
     image.variant(
       resize_to_limit: [500, 500],
       convert: 'webp',
       saver: { quality: 80 }
-    ).processed
+    )
   end
 
   def create_blob_from_image(image, filename, content_type)


### PR DESCRIPTION
## Summary

This PR improves image handling resilience for DrinkedIn by removing eager Active Storage variant processing from the cocktail index serialization path.

Previously, `ImageAttachable` generated image URLs by calling `.processed` on each Active Storage variant. This forced Rails to synchronously check or generate image variants while building responses such as `GET /cocktails`. After a stale local cache or missing variant files, the index request could block while Rails processed every cocktail image, causing the frontend to appear empty or delayed even though cocktail records existed.

This PR changes image URL generation to return lazy Active Storage variant URLs instead of forcing variant processing during serialization. Variants are now processed on demand when the browser requests the image, allowing the cocktail index response to return promptly.

The PR also adds defensive error handling around image URL generation so that a broken or missing image attachment returns `nil` instead of causing the entire index response to fail. The frontend already supports fallback image behavior, so missing image URLs now degrade gracefully instead of breaking cocktail rendering.

## Changes

- Removed `.processed` from the Active Storage variant generation path in `ImageAttachable`
- Updated image URL generation to return lazy variant URLs
- Added rescue/fallback handling around `processed_image_url`
- Renamed private method process_image → image_variant to reflect its new responsibility  
- Documented the decision in `docs/decisions/adr-002-remove-eager-variant-processing.md`
- Clarified the tradeoff between eager processing and first-load image flicker
- Confirmed this is an immediate hardening fix, not the final production image architecture

## Why

The previous implementation solved an older frontend flickering issue by ensuring variants were processed before the image URL was returned. That was reasonable in a single-image context, but it became problematic when reused inside collection/index serialization.

For `GET /cocktails`, the serializer calls the image URL method for every cocktail. With `.processed`, this created a blocking N+1-style image variant processing/checking pattern. In stale local development state, this could delay the entire cocktail response by several seconds or minutes.

This PR prioritizes a better failure mode:

- The cocktail index should return quickly
- One bad or missing image should not crash or delay the entire page
- Image processing should not happen inside read/index serialization
- Individual images may load slightly later on first request, but the page itself should remain usable

## Tradeoff

Removing `.processed` means the first browser request for a new variant may still trigger on-demand processing. This can result in brief image loading delay or flicker the first time a variant is requested.

That tradeoff is acceptable for this PR because the delay is now isolated to individual image requests instead of blocking the entire `/cocktails` response.

## Follow-up work

This PR intentionally keeps the public method names unchanged to avoid expanding the scope of the fix.

Later image-handling cleanup should rename methods to better reflect their new behavior. For example:

- `processed_image_url` should eventually become something like `image_url`, `variant_image_url`, or `display_image_url`

The current names imply eager processing, but after this PR the methods are primarily generating URLs for lazy variants. Renaming them should be handled in a later cleanup PR once the current resilience fix is merged and verified.

Future image architecture work should also consider:

- processing variants after upload instead of during read requests
- moving variant generation to background jobs
- adding clearer upload validations for file type, file size, and dimensions
- documenting local Active Storage recovery steps when DB records exist but local `storage/` files are missing
- eventually using cloud object storage for production images

## Acceptance criteria

- `GET /cocktails` returns promptly even when image variants are stale or missing
- One broken image attachment does not 500 the entire cocktails index
- Cocktail cards can render with fallback images when image URLs are `nil`
- Active Storage variant processing is no longer forced during index serialization
- ADR documents why `.processed` was originally introduced and why it is now being removed from this path