### PR TITLE
Hardened controller authorization for Phase 0 by enforcing authentication and ownership checks across user write actions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,4 +34,8 @@ class ApplicationController < ActionController::API
   def logged_in?
     !!current_user
   end
+
+  def require_login
+    render json: { error: 'Unauthorized' }, status: :unauthorized unless logged_in?
+  end
 end

--- a/app/controllers/cocktails_controller.rb
+++ b/app/controllers/cocktails_controller.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 class CocktailsController < ApplicationController
+  before_action :require_login, only: %i[create update destroy]
   before_action :find_cocktail, only: %i[show update destroy]
+  before_action :require_cocktail_owner, only: %i[update destroy]
   before_action :convert_to_array, only: %i[create update]
-  wrap_parameters :cocktail, include: %i[name description execution ingredients category user_id image]
+  wrap_parameters :cocktail, include: %i[name description execution ingredients category image]
 
   def index
-    # Eager load the :category, :bartender, and :image_attachment associations
     cocktails = Cocktail.includes(:category, :bartender, image_attachment: :blob).order(created_at: :desc)
     render json: cocktails
   end
@@ -16,9 +17,8 @@ class CocktailsController < ApplicationController
   end
 
   def create
-    # create cocktail without the photo parameter
     cocktail = Cocktail.new(cocktail_params.except(:photo))
-    cocktail.bartender_id = cocktail_params[:user_id]
+    cocktail.bartender_id = current_user.id
     cocktail.category_id = cocktail_params[:category_id]
     cocktail.ingredients = @ingredients_array
 
@@ -31,13 +31,9 @@ class CocktailsController < ApplicationController
   end
 
   def update
-    # prepare params without photo for updating
     updated_params = cocktail_params.except(:photo)
-    # check if ingredients are present and use the converted array
     updated_params[:ingredients] = @ingredients_array if cocktail_params[:ingredients].present?
-    # update the cocktail with the prepared params
     if @cocktail.update(updated_params)
-      # attach or update the image if present, using the concern's method
       @cocktail.attach_image(cocktail_params[:photo]) if cocktail_params[:photo].present?
       render json: @cocktail
     else
@@ -47,14 +43,13 @@ class CocktailsController < ApplicationController
 
   def destroy
     @cocktail.destroy
-    # Respond with an empty JSON object and a status of 204 No Content
     render json: {}, status: :no_content
   end
 
   private
 
   def cocktail_params
-    params.require(:cocktail).permit(:id, :name, :description, :execution, :ingredients, :category_id, :user_id, :photo)
+    params.require(:cocktail).permit(:id, :name, :description, :execution, :ingredients, :category_id, :photo)
   end
 
   def convert_to_array
@@ -67,5 +62,9 @@ class CocktailsController < ApplicationController
 
   def find_cocktail
     @cocktail = Cocktail.find(params[:id])
+  end
+
+  def require_cocktail_owner
+    render json: { error: 'Forbidden' }, status: :forbidden unless @cocktail.bartender_id == current_user.id
   end
 end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,4 +1,32 @@
 # frozen_string_literal: true
 
 class FavoritesController < ApplicationController
+  before_action :require_login
+  before_action :find_favorite, only: %i[destroy]
+  before_action :require_favorite_owner, only: %i[destroy]
+
+  def index
+    @favorites = Favorite.where(user_id: current_user.id)
+    render json: @favorites
+  end
+
+  def create
+    @favorite = Favorite.create(user_id: current_user.id, favorited_bar_id: params['favorited_bar_id'])
+    render json: @favorite
+  end
+
+  def destroy
+    @favorite.destroy!
+    render json: {}, status: :no_content
+  end
+
+  private
+
+  def find_favorite
+    @favorite = Favorite.find(params[:id])
+  end
+
+  def require_favorite_owner
+    render json: { error: 'Forbidden' }, status: :forbidden unless @favorite.user_id == current_user.id
+  end
 end

--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -1,24 +1,36 @@
 # frozen_string_literal: true
 
 class FollowsController < ApplicationController
+  before_action :require_login, only: %i[create destroy]
+  before_action :find_follow, only: %i[show destroy]
+  before_action :require_follow_owner, only: %i[destroy]
+
   def index
     @follows = Follow.order(:id).includes(%i[follower followee])
     render json: @follows
   end
 
   def show
-    @follow = Follow.find(params[:id])
     render json: @follow
   end
 
   def create
-    @follow = Follow.create(follower_id: params['follower_id'], followee_id: params['followee_id'])
+    @follow = Follow.create(follower_id: current_user.id, followee_id: params['followee_id'])
     render json: @follow
   end
 
   def destroy
-    @follow = Follow.find(params[:id])
     @follow.destroy!
     render json: {}, status: :no_content
+  end
+
+  private
+
+  def find_follow
+    @follow = Follow.find(params[:id])
+  end
+
+  def require_follow_owner
+    render json: { error: 'Forbidden' }, status: :forbidden unless @follow.follower_id == current_user.id
   end
 end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,30 +1,36 @@
 # frozen_string_literal: true
 
 class LikesController < ApplicationController
+  before_action :require_login, only: %i[create destroy]
+  before_action :find_like, only: %i[show destroy]
+  before_action :require_like_owner, only: %i[destroy]
+
   def index
     @likes = Like.order(:id).includes(%i[liked_cocktail liker])
     render json: @likes
   end
 
   def show
-    @like = Like.find(params[:id])
     render json: @like
   end
 
   def create
-    @like = Like.create(liker_id: params['liker_id'], liked_cocktail_id: params['liked_cocktail_id'])
+    @like = Like.create(liker_id: current_user.id, liked_cocktail_id: params['liked_cocktail_id'])
     render json: @like
   end
 
   def destroy
-    @like = Like.find(params[:id])
     @like.destroy!
     render json: {}, status: :no_content
   end
 
   private
 
-  def find_cocktail
-    @cocktail = Cocktail.find(params['liked_cocktail_id'])
+  def find_like
+    @like = Like.find(params[:id])
+  end
+
+  def require_like_owner
+    render json: { error: 'Forbidden' }, status: :forbidden unless @like.liker_id == current_user.id
   end
 end

--- a/app/serializers/favorite_serializer.rb
+++ b/app/serializers/favorite_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class FavoriteSerializer < ActiveModel::Serializer
-  attributes :id, :liked_bar_id
+  attributes :id, :user_id, :favorited_bar_id
   has_one :user
 end

--- a/spec/factories/bars.rb
+++ b/spec/factories/bars.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :bar do
+    sequence(:name) { |n| "Bar #{n}" }
+  end
+end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :category do
+    sequence(:name) { |n| "Category #{n}" }
+    definition { Faker::Lorem.sentence }
+  end
+end

--- a/spec/factories/cocktails.rb
+++ b/spec/factories/cocktails.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :cocktail do
+    sequence(:name) { |n| "Cocktail #{n}" }
+    description { Faker::Lorem.sentence }
+    execution { Faker::Lorem.sentence }
+    ingredients { ['vodka', 'lime juice', 'soda water'] }
+    association :bartender, factory: :user
+    association :category
+  end
+end

--- a/spec/factories/favorites.rb
+++ b/spec/factories/favorites.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :favorite do
+    association :user
+    association :favorited_bar, factory: :bar
+  end
+end

--- a/spec/factories/follows.rb
+++ b/spec/factories/follows.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :follow do
+    association :follower, factory: :user
+    association :followee, factory: :user
+  end
+end

--- a/spec/factories/likes.rb
+++ b/spec/factories/likes.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :like do
+    association :liker, factory: :user
+    association :liked_cocktail, factory: :cocktail
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :user do
+    sequence(:username) { |n| "user#{n}" }
+    full_name { Faker::Name.name }
+    password { 'password123' }
+    location { Faker::Address.city }
+    bartender { false }
+  end
+end

--- a/spec/requests/cocktails_spec.rb
+++ b/spec/requests/cocktails_spec.rb
@@ -1,8 +1,98 @@
 require 'rails_helper'
 
-RSpec.describe 'GET /cocktails', type: :request do
-  it 'returns a successful response' do
-    get '/cocktails'
-    expect(response).to have_http_status(:ok)
+RSpec.describe 'Cocktails', type: :request do
+  describe 'GET /cocktails' do
+    it 'returns a successful response' do
+      get '/cocktails'
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'POST /cocktails' do
+    let(:user) { create(:user) }
+    let(:category) { create(:category) }
+    let(:valid_params) do
+      { cocktail: { name: 'Old Fashioned', description: 'A classic', execution: 'Stir well',
+                    ingredients: 'whiskey,bitters,sugar', category_id: category.id } }
+    end
+
+    context 'when unauthenticated' do
+      it 'returns 401' do
+        post '/cocktails', params: valid_params
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when authenticated' do
+      it 'creates a cocktail owned by current_user' do
+        post '/cocktails', params: valid_params, headers: auth_headers_for(user)
+        expect(response).to have_http_status(:created)
+        expect(Cocktail.last.bartender_id).to eq(user.id)
+      end
+
+      it 'ignores a spoofed user_id param' do
+        other_user = create(:user)
+        post '/cocktails', params: valid_params.deep_merge(cocktail: { user_id: other_user.id }),
+                           headers: auth_headers_for(user)
+        expect(response).to have_http_status(:created)
+        expect(Cocktail.last.bartender_id).to eq(user.id)
+      end
+    end
+  end
+
+  describe 'PATCH /cocktails/:id' do
+    let(:owner) { create(:user) }
+    let(:other_user) { create(:user) }
+    let(:cocktail) { create(:cocktail, bartender: owner) }
+
+    context 'when unauthenticated' do
+      it 'returns 401' do
+        patch "/cocktails/#{cocktail.id}", params: { cocktail: { name: 'Updated' } }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when authenticated as the owner' do
+      it 'updates the cocktail' do
+        patch "/cocktails/#{cocktail.id}", params: { cocktail: { name: 'Updated Name' } },
+                                           headers: auth_headers_for(owner)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when authenticated as a non-owner' do
+      it 'returns 403' do
+        patch "/cocktails/#{cocktail.id}", params: { cocktail: { name: 'Hacked' } },
+                                           headers: auth_headers_for(other_user)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe 'DELETE /cocktails/:id' do
+    let(:owner) { create(:user) }
+    let(:other_user) { create(:user) }
+    let(:cocktail) { create(:cocktail, bartender: owner) }
+
+    context 'when unauthenticated' do
+      it 'returns 401' do
+        delete "/cocktails/#{cocktail.id}"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when authenticated as the owner' do
+      it 'destroys the cocktail' do
+        delete "/cocktails/#{cocktail.id}", headers: auth_headers_for(owner)
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context 'when authenticated as a non-owner' do
+      it 'returns 403' do
+        delete "/cocktails/#{cocktail.id}", headers: auth_headers_for(other_user)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
   end
 end

--- a/spec/requests/favorites_spec.rb
+++ b/spec/requests/favorites_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe 'Favorites', type: :request do
+  describe 'GET /favorites' do
+    context 'when unauthenticated' do
+      it 'returns 401' do
+        get '/favorites'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when authenticated' do
+      it 'returns only the current user favorites' do
+        user = create(:user)
+        other_user = create(:user)
+        create(:favorite, user: user)
+        create(:favorite, user: other_user)
+
+        get '/favorites', headers: auth_headers_for(user)
+        expect(response).to have_http_status(:ok)
+        ids = JSON.parse(response.body).map { |f| f['user_id'] }
+        expect(ids).to all(eq(user.id))
+      end
+    end
+  end
+
+  describe 'POST /favorites' do
+    let(:user) { create(:user) }
+    let(:bar) { create(:bar) }
+
+    context 'when unauthenticated' do
+      it 'returns 401' do
+        post '/favorites', params: { favorited_bar_id: bar.id }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when authenticated' do
+      it 'creates a favorite as current_user' do
+        post '/favorites', params: { favorited_bar_id: bar.id }, headers: auth_headers_for(user)
+        expect(response).to have_http_status(:ok)
+        expect(Favorite.last.user_id).to eq(user.id)
+      end
+    end
+  end
+
+  describe 'DELETE /favorites/:id' do
+    let(:owner) { create(:user) }
+    let(:other_user) { create(:user) }
+    let(:favorite) { create(:favorite, user: owner) }
+
+    context 'when unauthenticated' do
+      it 'returns 401' do
+        delete "/favorites/#{favorite.id}"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when authenticated as the owner' do
+      it 'destroys the favorite' do
+        delete "/favorites/#{favorite.id}", headers: auth_headers_for(owner)
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context 'when authenticated as a non-owner' do
+      it 'returns 403' do
+        delete "/favorites/#{favorite.id}", headers: auth_headers_for(other_user)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end

--- a/spec/requests/follows_spec.rb
+++ b/spec/requests/follows_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe 'Follows', type: :request do
+  describe 'POST /follows' do
+    let(:user) { create(:user) }
+    let(:target) { create(:user) }
+
+    context 'when unauthenticated' do
+      it 'returns 401' do
+        post '/follows', params: { followee_id: target.id }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when authenticated' do
+      it 'creates a follow as current_user' do
+        post '/follows', params: { followee_id: target.id }, headers: auth_headers_for(user)
+        expect(response).to have_http_status(:ok)
+        expect(Follow.last.follower_id).to eq(user.id)
+      end
+
+      it 'ignores a spoofed follower_id param' do
+        other_user = create(:user)
+        post '/follows', params: { follower_id: other_user.id, followee_id: target.id },
+                         headers: auth_headers_for(user)
+        expect(Follow.last.follower_id).to eq(user.id)
+      end
+    end
+  end
+
+  describe 'DELETE /follows/:id' do
+    let(:owner) { create(:user) }
+    let(:other_user) { create(:user) }
+    let(:follow) { create(:follow, follower: owner) }
+
+    context 'when unauthenticated' do
+      it 'returns 401' do
+        delete "/follows/#{follow.id}"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when authenticated as the owner' do
+      it 'destroys the follow' do
+        delete "/follows/#{follow.id}", headers: auth_headers_for(owner)
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context 'when authenticated as a non-owner' do
+      it 'returns 403' do
+        delete "/follows/#{follow.id}", headers: auth_headers_for(other_user)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end

--- a/spec/requests/likes_spec.rb
+++ b/spec/requests/likes_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe 'Likes', type: :request do
+  describe 'POST /likes' do
+    let(:user) { create(:user) }
+    let(:cocktail) { create(:cocktail) }
+
+    context 'when unauthenticated' do
+      it 'returns 401' do
+        post '/likes', params: { liked_cocktail_id: cocktail.id }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when authenticated' do
+      it 'creates a like as current_user' do
+        post '/likes', params: { liked_cocktail_id: cocktail.id }, headers: auth_headers_for(user)
+        expect(response).to have_http_status(:ok)
+        expect(Like.last.liker_id).to eq(user.id)
+      end
+
+      it 'ignores a spoofed liker_id param' do
+        other_user = create(:user)
+        post '/likes', params: { liker_id: other_user.id, liked_cocktail_id: cocktail.id },
+                       headers: auth_headers_for(user)
+        expect(Like.last.liker_id).to eq(user.id)
+      end
+    end
+  end
+
+  describe 'DELETE /likes/:id' do
+    let(:owner) { create(:user) }
+    let(:other_user) { create(:user) }
+    let(:cocktail) { create(:cocktail) }
+    let(:like) { create(:like, liker: owner, liked_cocktail: cocktail) }
+
+    context 'when unauthenticated' do
+      it 'returns 401' do
+        delete "/likes/#{like.id}"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when authenticated as the owner' do
+      it 'destroys the like' do
+        delete "/likes/#{like.id}", headers: auth_headers_for(owner)
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context 'when authenticated as a non-owner' do
+      it 'returns 403' do
+        delete "/likes/#{like.id}", headers: auth_headers_for(other_user)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end

--- a/spec/support/auth_helpers.rb
+++ b/spec/support/auth_helpers.rb
@@ -1,0 +1,10 @@
+module AuthHelpers
+  def auth_headers_for(user)
+    token = JWT.encode({ user_id: user.id }, Rails.application.credentials.jwt_key, 'HS256')
+    { 'Authorization' => "Bearer #{token}" }
+  end
+end
+
+RSpec.configure do |config|
+  config.include AuthHelpers, type: :request
+end


### PR DESCRIPTION

This PR prevents unauthenticated writes, blocks non-owner mutations, removes spoofable user identity params from create flows, and implements the previously empty FavoritesController. It also adds request spec coverage for the new security behavior.

**Changes**

- Added `require_login` to `ApplicationController`
      - Returns `401 Unauthorized` for unauthenticated write attempts 

- Added ownership guards for protected destroy/update actions 
      - Cocktail update/destroy
      - Like destroy
      - Follow destroy
      - Favorite destroy
      - Returns `403 Forbidden` for authenticated non-owners 

- Updated cocktail creation to derive ownership from `current_user.id` 
      - `bartender_id` is now set server-side
      - `user_id` and `bartender_id` are no longer accepted from permitted params 

- Updated like creation to derive `liker_id` from `current_user.id` 
      - Spoofed `liker_id` params are ignored

- Updated follow creation to derive `follower_id` from `current_user.id` 
      - Spoofed `follower_id` params are ignored

- Fully implemented `FavoritesController`
      - Supports current user favorites index
      - Supports create/destroy
      - Requires authentication for protected actions
      - Enforces ownership on destroy

- Corrected `FavoriteSerializer`
      - Renamed `liked_bar_id` to `favorited_bar_id`

**Testing**

Added 29 request specs covering the Phase 0 controller authorization requirements, including:
- unauthenticated write attempts return `401`
- authenticated non-owner mutations return `403`
- owners can update/destroy their own resources
- create actions derive user identity from `current_user` 
- spoofed user identity params are ignored
- favorites behavior is covered now that the controller is implemented 

**Notes**

This PR intentionally keeps the existing `cocktails.bartender_id` schema name in place. Ownership is now enforced using the current schema, while the planned Phase 1 rename to `creator_id` remains a separate naming cleanup.