### PR TITLE
Validate image uploads before Active Storage attach

### DIFF
--- a/app/controllers/cocktails_controller.rb
+++ b/app/controllers/cocktails_controller.rb
@@ -22,22 +22,36 @@ class CocktailsController < ApplicationController
     cocktail.category_id = cocktail_params[:category_id]
     cocktail.ingredients = @ingredients_array
 
+    if cocktail_params[:photo].present?
+      upload_errors = cocktail.image_upload_errors(cocktail_params[:photo])
+      return render json: { errors: upload_errors }, status: :unprocessable_entity if upload_errors.any?
+
+      cocktail.attach_image(cocktail_params[:photo])
+    end
+
     if cocktail.save
-      cocktail.attach_image(cocktail_params[:photo]) if cocktail_params[:photo].present?
       render json: cocktail, status: :created
     else
-      render json: { error: 'failed to create cocktail' }, status: :not_acceptable
+      render json: { errors: cocktail.errors.full_messages }, status: :unprocessable_entity
     end
   end
 
   def update
     updated_params = cocktail_params.except(:photo)
     updated_params[:ingredients] = @ingredients_array if cocktail_params[:ingredients].present?
-    if @cocktail.update(updated_params)
-      @cocktail.attach_image(cocktail_params[:photo]) if cocktail_params[:photo].present?
+    @cocktail.assign_attributes(updated_params)
+
+    if cocktail_params[:photo].present?
+      upload_errors = @cocktail.image_upload_errors(cocktail_params[:photo])
+      return render json: { errors: upload_errors }, status: :unprocessable_entity if upload_errors.any?
+
+      @cocktail.attach_image(cocktail_params[:photo])
+    end
+
+    if @cocktail.save
       render json: @cocktail
     else
-      render json: { error: 'failed to update cocktail' }, status: :unprocessable_entity
+      render json: { errors: @cocktail.errors.full_messages }, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+# NOTE: This controller is broken legacy code and is out of scope for the current phase.
+# It references `cocktail.photo`, `user.avatar`, and `user.profile_pic` — none of which
+# exist on the current models. All image handling is done via ImageAttachable using the
+# `image` attachment. Both endpoints would raise NoMethodError if called. No authentication
+# guard is present either. Flagged for removal in a separate cleanup PR.
 class ImagesController < ApplicationController
   def update
     cocktail = Cocktail.find(params[:id])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,7 +18,6 @@ class UsersController < ApplicationController
     user = User.create(user_params)
 
     if user.save
-      # invoke issue_token helper method defined in ApplicationController
       token = issue_token(user)
       render json: { user: UserSerializer.new(user), jwt: token }, status: :created
     elsif user.errors.messages
@@ -35,21 +34,24 @@ class UsersController < ApplicationController
   end
 
   def me
-    # token present in headers would be used to find the current user
     render json: current_user
   end
 
   def update
-    # token present in headers would be used to find the current user
-    # prepare user params without avatar for updating
     updated_params = user_params.except(:avatar)
-    # update the user with the prepared params
-    if current_user.update(updated_params)
-      # attach or update the avatar if present
-      current_user.attach_image(user_params[:avatar]) if user_params[:avatar].present?
+    current_user.assign_attributes(updated_params)
+
+    if user_params[:avatar].present?
+      upload_errors = current_user.image_upload_errors(user_params[:avatar])
+      return render json: { errors: upload_errors }, status: :unprocessable_entity if upload_errors.any?
+
+      current_user.attach_image(user_params[:avatar])
+    end
+
+    if current_user.save
       render json: current_user
     else
-      render json: { error: 'failed to update user' }, status: :unprocessable_entity
+      render json: { errors: current_user.errors.full_messages }, status: :unprocessable_entity
     end
   end
 
@@ -61,7 +63,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    # omit id from user params for security
     params.require(:user).permit(:full_name, :username, :password, :location, :bartender, :avatar)
   end
 end

--- a/app/models/concerns/image_attachable.rb
+++ b/app/models/concerns/image_attachable.rb
@@ -3,8 +3,30 @@
 module ImageAttachable
   extend ActiveSupport::Concern
 
+  ALLOWED_CONTENT_TYPES = %w[image/jpeg image/png image/webp].freeze
+  MAX_FILE_SIZE = 5.megabytes
+
   included do
     has_one_attached :image
+  end
+
+  # Returns an array of human-readable error strings.
+  # Empty array means the file is acceptable.
+  # For Base64 uploads: content type is accepted based on assigned metadata (image/png);
+  # size is validated against the decoded byte count.
+  # Byte-level content verification is deferred to a later phase.
+  def image_upload_errors(file)
+    if file.is_a?(ActionDispatch::Http::UploadedFile)
+      errors = []
+      errors << 'must be a JPEG, PNG, or WebP image' unless ALLOWED_CONTENT_TYPES.include?(file.content_type)
+      errors << 'must be less than 5MB' if file.size > MAX_FILE_SIZE
+      errors
+    elsif file.is_a?(String) && file.start_with?('data:image')
+      decoded_size = Base64.decode64(file.split(',')[1]).bytesize
+      decoded_size > MAX_FILE_SIZE ? ['must be less than 5MB'] : []
+    else
+      []
+    end
   end
 
   def attach_image(image_params)
@@ -13,7 +35,6 @@ module ImageAttachable
     if image_params.is_a?(ActionDispatch::Http::UploadedFile)
       image.attach(image_params)
     elsif image_params.is_a?(String) && image_params.starts_with?('data:image')
-      # decode Base64 image
       decoded_image = Base64.decode64(image_params.split(',')[1])
       image_io = StringIO.new(decoded_image)
       blob = create_blob_from_image(image_io, 'uploaded_image.png', 'image/png')

--- a/spec/requests/cocktails_spec.rb
+++ b/spec/requests/cocktails_spec.rb
@@ -69,6 +69,59 @@ RSpec.describe 'Cocktails', type: :request do
     end
   end
 
+  describe 'photo upload validation' do
+    let(:user) { create(:user) }
+    let(:category) { create(:category) }
+    let(:base_params) do
+      { cocktail: { name: 'Sunset Spritz', description: 'Refreshing', execution: 'Shake',
+                    ingredients: 'gin,tonic', category_id: category.id } }
+    end
+
+    context 'on POST /cocktails' do
+      it 'rejects a non-image content type with 422 and errors key' do
+        post '/cocktails',
+             params: base_params.deep_merge(cocktail: { photo: invalid_type_upload }),
+             headers: auth_headers_for(user)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)).to have_key('errors')
+      end
+
+      it 'rejects a GIF with 422' do
+        post '/cocktails',
+             params: base_params.deep_merge(cocktail: { photo: gif_upload }),
+             headers: auth_headers_for(user)
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'rejects an oversized file with 422 and errors key' do
+        post '/cocktails',
+             params: base_params.deep_merge(cocktail: { photo: oversized_upload }),
+             headers: auth_headers_for(user)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)).to have_key('errors')
+      end
+    end
+
+    context 'on PATCH /cocktails/:id' do
+      let(:cocktail) { create(:cocktail, bartender: user) }
+
+      it 'rejects a non-image content type with 422 and errors key' do
+        patch "/cocktails/#{cocktail.id}",
+              params: { cocktail: { photo: invalid_type_upload } },
+              headers: auth_headers_for(user)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)).to have_key('errors')
+      end
+
+      it 'rejects an oversized file with 422' do
+        patch "/cocktails/#{cocktail.id}",
+              params: { cocktail: { photo: oversized_upload } },
+              headers: auth_headers_for(user)
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
   describe 'DELETE /cocktails/:id' do
     let(:owner) { create(:user) }
     let(:other_user) { create(:user) }

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe 'Users', type: :request do
+  describe 'PATCH /me avatar upload validation' do
+    let(:user) { create(:user) }
+
+    it 'rejects a non-image content type with 422 and errors key' do
+      patch '/me',
+            params: { user: { avatar: invalid_type_upload } },
+            headers: auth_headers_for(user)
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body)).to have_key('errors')
+    end
+
+    it 'rejects a GIF with 422' do
+      patch '/me',
+            params: { user: { avatar: gif_upload } },
+            headers: auth_headers_for(user)
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it 'rejects an oversized file with 422 and errors key' do
+      patch '/me',
+            params: { user: { avatar: oversized_upload } },
+            headers: auth_headers_for(user)
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body)).to have_key('errors')
+    end
+
+    it 'accepts a valid image and returns 200' do
+      patch '/me',
+            params: { user: { avatar: valid_image_upload } },
+            headers: auth_headers_for(user)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/support/upload_helpers.rb
+++ b/spec/support/upload_helpers.rb
@@ -1,0 +1,33 @@
+module UploadHelpers
+  def invalid_type_upload
+    file = Tempfile.new(['test', '.txt'])
+    file.write('not an image')
+    file.rewind
+    Rack::Test::UploadedFile.new(file.path, 'text/plain')
+  end
+
+  def gif_upload
+    file = Tempfile.new(['test', '.gif'])
+    file.write('GIF89a fake gif')
+    file.rewind
+    Rack::Test::UploadedFile.new(file.path, 'image/gif')
+  end
+
+  def oversized_upload(content_type: 'image/jpeg')
+    file = Tempfile.new(['oversized', '.jpg'])
+    file.write('a' * (ImageAttachable::MAX_FILE_SIZE + 1).to_i)
+    file.rewind
+    Rack::Test::UploadedFile.new(file.path, content_type)
+  end
+
+  def valid_image_upload(content_type: 'image/jpeg')
+    file = Tempfile.new(['valid', '.jpg'])
+    file.write('fake image bytes')
+    file.rewind
+    Rack::Test::UploadedFile.new(file.path, content_type)
+  end
+end
+
+RSpec.configure do |config|
+  config.include UploadHelpers, type: :request
+end


### PR DESCRIPTION
This PR adds pre-attachment validation for user-uploaded images before they are passed to Active Storage.

Previously, cocktail photo and user avatar uploads were attached without validating content type or file size. Because Active Storage can create/upload blobs as soon as `attach` is called, this PR validates uploads before attachment so invalid files are rejected before they reach storage.

**Changes**

- Added upload validation logic to ImageAttachable
      - Allows JPEG, PNG, and WebP images
      - Rejects files larger than 5MB
      - Supports validation for both multipart uploads and Base64 uploads
- Updated cocktail image upload flow
      - Validates uploads on CocktailsController#create
      - Restructures CocktailsController#update to assign attributes, validate the upload, attach the image, then save
- Updated user avatar upload flow
      - Restructures UsersController#update to assign attributes, validate the upload, attach the image, then save
- Returns 422 Unprocessable Entity when an upload fails validation
- Adds request specs covering valid uploads, invalid content types, and oversized files where applicable

**Notes**

- The `active_storage_validations` gem remains in the Gemfile but is not used in this PR. This PR intentionally validates before calling Active Storage so rejected uploads do not create stored blobs.
- Base64 uploads continue to use the existing `image/png` behavior. Size validation is applied to the decoded image data.
- `ImagesController` was identified as dead/broken legacy code because it references removed image columns and lacks an auth guard. It is intentionally left unchanged for a separate cleanup PR.
- MIME spoofing and magic-byte inspection are out of scope for this PR and can be addressed in a later phase.