### PR TITLE
Upgrade Brakeman and restore security scan baseline

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'ruby-vips', '~> 2.0', '>= 2.0.17'
 # library and registry for information about MIME content type definitions
 gem 'mime-types'
 # detect security vulnerabilities in Rails application via static analysis
-gem 'brakeman', '~> 3.3', '>= 3.3.2'
+gem 'brakeman', '~> 6.0'
 
 # static code analyzer and formatter for Ruby
 gem 'rubocop', '~> 1.62', '>= 1.62.1', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,8 @@ GEM
     bcrypt (3.1.20)
     bootsnap (1.17.0)
       msgpack (~> 1.2)
-    brakeman (3.7.2)
+    brakeman (6.2.2)
+      racc
     builder (3.2.4)
     bullet (7.1.6)
       activesupport (>= 3.0.0)
@@ -298,7 +299,7 @@ DEPENDENCIES
   awesome_print
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.4)
-  brakeman (~> 3.3, >= 3.3.2)
+  brakeman (~> 6.0)
   bullet (~> 7.1, >= 7.1.6)
   debug (~> 1.9, >= 1.9.2)
   dotenv-rails

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,10 @@
+{
+  "ignored_warnings": [
+    {
+      "fingerprint": "d84924377155b41e094acae7404ec2e521629d86f97b0ff628e3d1b263f8101c",
+      "note": "Rails 7.0.8 EOL is a known issue. Upgrade to Rails 7.2 is planned and tracked in Phase 1 of the roadmap. This warning is deferred, not dismissed."
+    }
+  ],
+  "updated": "2026-06-02",
+  "brakeman_version": "6.2.2"
+}


### PR DESCRIPTION
This PR restores Brakeman security scanning for the Rails backend by upgrading Brakeman from 3.7.2 to 6.2.2.

The previous Brakeman version was incompatible with the project’s current Ruby 3.3 environment and crashed before completing a scan. This meant the codebase had no functioning static security scan baseline. After the upgrade, Brakeman now runs successfully across the full application.

The completed scan covered:

- 12 controllers
- 9 models
- 1 template

The scan reports **0 active warnings**.

One high-confidence finding was identified: the project is currently on Rails 7.0.8, which is end-of-life. This is a valid finding, but it is intentionally deferred to the planned Phase 1 Rails upgrade rather than being handled in this PR. The finding is documented in config/brakeman.ignore with justification so Brakeman can continue to run cleanly while preserving visibility into the deferred work.

Brakeman now exits successfully with:

`brakeman -q --ignore-config config/brakeman.ignore`

This PR establishes a working Brakeman baseline for future security-sensitive changes.