### PR TITLE
Add Active Storage dev diagnostics and missing-image troubleshooting

### DIFF
--- a/lib/tasks/storage.rake
+++ b/lib/tasks/storage.rake
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+namespace :storage do
+  desc 'Report Active Storage health: missing blob files and existing variant records'
+  task verify: :environment do
+    blobs = ActiveStorage::Blob.all
+    missing_blobs = blobs.reject do |blob|
+      blob.service.exist?(blob.key)
+    rescue StandardError
+      false
+    end
+
+    variant_count = ActiveStorage::VariantRecord.count
+
+    puts "Active Storage health check"
+    puts "---------------------------"
+    puts "Blobs total:          #{blobs.count}"
+    puts "Blobs missing files:  #{missing_blobs.count}"
+    puts "Variant records:      #{variant_count}"
+
+    if variant_count.positive?
+      puts ""
+      puts "Note: #{variant_count} variant record(s) exist from previous image processing runs."
+      puts "These are normal — they cache processed image variants and are not errors."
+    end
+
+    puts ""
+
+    if missing_blobs.any?
+      puts "WARNING: #{missing_blobs.count} blob(s) have no backing file in storage/."
+      puts ""
+      puts "storage/ is gitignored. Blob records in the database point to files"
+      puts "that are no longer present. Reseeding alone will not fix this — it"
+      puts "creates new blob records but leaves the old stale references in place."
+      puts ""
+      puts "Fix: reset the database and reseed from scratch."
+      puts "  docker compose exec web rails db:reset"
+      puts "  docker compose exec web rails db:seed"
+    else
+      puts "OK: all blobs have backing files."
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds developer-facing diagnostics and troubleshooting guidance for Active Storage image issues in local development.

### What changed

* Added a `rails storage:verify` rake task that:

  * checks every Active Storage blob using `blob.service.exist?`
  * works with any configured storage service, including local disk, S3, and GCS
  * reports blobs whose backing files are missing
  * reports existing variant records as informational
  * exits successfully in all cases so it remains a diagnostic tool rather than a destructive or CI-blocking check

* Added an Active Storage troubleshooting entry to the parent README explaining:

  * `storage/` is gitignored while source cocktail images under `public/photos/cocktails/` are committed
  * clearing `storage/` without resetting the database leaves stale blob and attachment records pointing to missing files
  * reseeding alone may not repair that mismatch
  * the correct local-development recovery command is:

  ```bash
  rails db:reset && rails db:seed
  ```

### Scope

This PR does not modify seed behavior, storage configuration, database records, or Active Storage processing. Existing blobs, attachments, files, and variant records were verified as healthy, so no cleanup was required.
